### PR TITLE
CI: expand PR validation (lint, PDK matrix, shellcheck, PSScriptAnalyzer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,17 @@ on:
       - main
   workflow_dispatch:
 
+# Cancel superseded runs on the same ref (e.g. rapid PR pushes).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   validate:
-    name: Validate and test
+    name: PDK validate (lint, rubocop, metadata, tasks)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,8 +36,70 @@ jobs:
       - name: Install module dependencies
         run: pdk bundle install
 
-      - name: Validate
-        run: pdk validate --format text
+      - name: Validate (puppet, ruby, metadata, tasks)
+        run: pdk validate --format text --parallel
+
+  unit:
+    name: Unit tests (Puppet ${{ matrix.puppet_version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Module supports puppet >= 7.24.0 < 9.0.0 (see metadata.json)
+          - puppet_version: '7'
+            puppet_gem_version: '~> 7.24'
+          - puppet_version: '8'
+            puppet_gem_version: '~> 8.0'
+    env:
+      PUPPET_GEM_VERSION: ${{ matrix.puppet_gem_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install PDK
+        run: gem install pdk
+
+      - name: Install module dependencies
+        run: pdk bundle install
 
       - name: Unit tests
         run: pdk test unit
+
+  shellcheck:
+    name: ShellCheck (bash task implementations)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: ./tasks
+          additional_files: '*.sh'
+
+  powershell:
+    name: PSScriptAnalyzer (PowerShell task implementations)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+          $results = Invoke-ScriptAnalyzer -Path ./tasks -Recurse -Severity Warning,Error
+          if ($results) {
+            $results | Format-Table -AutoSize | Out-String | Write-Host
+            Write-Error "PSScriptAnalyzer found $($results.Count) issue(s)."
+            exit 1
+          }
+          Write-Host "PSScriptAnalyzer found no issues."

--- a/tasks/disable_agent_bash.sh
+++ b/tasks/disable_agent_bash.sh
@@ -12,4 +12,6 @@ if [ ! -x "${puppet_bin}" ]; then
   puppet_bin="$(command -v puppet)"
 fi
 
+# PT_reason is supplied by Bolt as an environment variable at runtime.
+# shellcheck disable=SC2154
 "${puppet_bin}" agent --disable "${PT_reason}"


### PR DESCRIPTION
## Summary
Expands the CI workflow from a single validate/test job into a full PR validation pipeline.

## Jobs (run on every PR to `main`)
- **PDK validate** — Puppet syntax, puppet-lint, rubocop, metadata-json-lint, and Bolt task metadata validation (`--parallel`)
- **Unit tests** — `pdk test unit` across a **Puppet 7** and **Puppet 8** matrix (matches `metadata.json` `>= 7.24.0 < 9.0.0`)
- **ShellCheck** — lints the `.sh` task implementations
- **PSScriptAnalyzer** — lints the `.ps1` task implementations (Warning/Error severity)

## Other
- `concurrency` cancellation for rapid PR pushes
- least-privilege `contents: read` token
- scoped `# shellcheck disable=SC2154` for `PT_reason` in `disable_agent_bash.sh` (Bolt injects it at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)